### PR TITLE
Security Export: Issues, Dependabot & CodeScan Alerts (2026-06-28)

### DIFF
--- a/issues/README.md
+++ b/issues/README.md
@@ -1,0 +1,24 @@
+# Repository: FreeDom
+
+**Description:** A free and open-source minimal web browser written in C, focused on Zero Trust and Zero Knowledge principles.
+
+| Metric | Value |
+|--------|-------|
+| ⭐ Stars | 7 |
+| 📥 Clones (last 14 days) | 1453 |
+| 🟢 Open Issues | 1 |
+| 📋 Total Issues | 0 |
+| 🛡 Dependabot Open Alerts | 0 |
+| 🔍 CodeScan Open Alerts | 6 |
+
+## Issues
+
+## Code Scanning Alerts
+- [CodeScan #13](./codescan/alert_13.md) - cpp/overflowing-snprintf (warning) - open
+- [CodeScan #12](./codescan/alert_12.md) - cpp/non-https-url (warning) - open
+- [CodeScan #11](./codescan/alert_11.md) - actions/missing-workflow-permissions (warning) - open
+- [CodeScan #4](./codescan/alert_4.md) - cpp/non-https-url (warning) - open
+- [CodeScan #3](./codescan/alert_3.md) - cpp/non-https-url (warning) - open
+- [CodeScan #2](./codescan/alert_2.md) - cpp/integer-multiplication-cast-to-long (warning) - open
+
+Total issues downloaded: 0

--- a/issues/codescan/alert_11.md
+++ b/issues/codescan/alert_11.md
@@ -1,0 +1,10 @@
+# Code Scanning Alert #11: actions/missing-workflow-permissions
+
+- **State:** open
+- **Severity:** warning
+- **Tool:** CodeQL
+- **Created:** 2026-06-19T01:12:11Z
+- **URL:** https://github.com/grisuno/FreeDom/security/code-scanning/11
+
+## Description
+Workflow does not contain permissions

--- a/issues/codescan/alert_12.md
+++ b/issues/codescan/alert_12.md
@@ -1,0 +1,10 @@
+# Code Scanning Alert #12: cpp/non-https-url
+
+- **State:** open
+- **Severity:** warning
+- **Tool:** CodeQL
+- **Created:** 2026-06-20T19:29:58Z
+- **URL:** https://github.com/grisuno/FreeDom/security/code-scanning/12
+
+## Description
+Failure to use HTTPS URLs

--- a/issues/codescan/alert_13.md
+++ b/issues/codescan/alert_13.md
@@ -1,0 +1,10 @@
+# Code Scanning Alert #13: cpp/overflowing-snprintf
+
+- **State:** open
+- **Severity:** warning
+- **Tool:** CodeQL
+- **Created:** 2026-06-28T15:37:22Z
+- **URL:** https://github.com/grisuno/FreeDom/security/code-scanning/13
+
+## Description
+Potentially overflowing call to snprintf

--- a/issues/codescan/alert_2.md
+++ b/issues/codescan/alert_2.md
@@ -1,0 +1,10 @@
+# Code Scanning Alert #2: cpp/integer-multiplication-cast-to-long
+
+- **State:** open
+- **Severity:** warning
+- **Tool:** CodeQL
+- **Created:** 2026-06-19T00:48:55Z
+- **URL:** https://github.com/grisuno/FreeDom/security/code-scanning/2
+
+## Description
+Multiplication result converted to larger type

--- a/issues/codescan/alert_3.md
+++ b/issues/codescan/alert_3.md
@@ -1,0 +1,10 @@
+# Code Scanning Alert #3: cpp/non-https-url
+
+- **State:** open
+- **Severity:** warning
+- **Tool:** CodeQL
+- **Created:** 2026-06-19T00:48:55Z
+- **URL:** https://github.com/grisuno/FreeDom/security/code-scanning/3
+
+## Description
+Failure to use HTTPS URLs

--- a/issues/codescan/alert_4.md
+++ b/issues/codescan/alert_4.md
@@ -1,0 +1,10 @@
+# Code Scanning Alert #4: cpp/non-https-url
+
+- **State:** open
+- **Severity:** warning
+- **Tool:** CodeQL
+- **Created:** 2026-06-19T00:48:55Z
+- **URL:** https://github.com/grisuno/FreeDom/security/code-scanning/4
+
+## Description
+Failure to use HTTPS URLs


### PR DESCRIPTION
Automated security export generated on 20260628_171901.

This PR adds a snapshot under `issues/` with:
- All GitHub issues (open + closed) as `issue_<n>.md`
- Open Dependabot alerts under `issues/dependabot/`
- Open Code Scanning alerts under `issues/codescan/`
- Index in `issues/README.md`

Generated by `security_issue_progressive.sh`.