### PR TITLE
Security Export: Issues, Dependabot & CodeScan Alerts

### DIFF
--- a/issues/README.md
+++ b/issues/README.md
@@ -4,20 +4,17 @@
 
 | Metric | Value |
 |--------|-------|
-| ⭐ Stars | 7 |
-| 📥 Clones (last 14 days) | 1453 |
-<<<<<<< HEAD
-| 🟢 Open Issues | 0 |
-=======
+| ⭐ Stars | 17 |
+| 📥 Clones (last 14 days) | 1070 |
 | 🟢 Open Issues | 1 |
->>>>>>> origin/security-export-2026-06-28-20260628_171901
 | 📋 Total Issues | 0 |
 | 🛡 Dependabot Open Alerts | 0 |
-| 🔍 CodeScan Open Alerts | 6 |
+| 🔍 CodeScan Open Alerts | 7 |
 
 ## Issues
 
 ## Code Scanning Alerts
+- [CodeScan #14](./codescan/alert_14.md) - cpp/overflowing-snprintf (warning) - open
 - [CodeScan #13](./codescan/alert_13.md) - cpp/overflowing-snprintf (warning) - open
 - [CodeScan #12](./codescan/alert_12.md) - cpp/non-https-url (warning) - open
 - [CodeScan #11](./codescan/alert_11.md) - actions/missing-workflow-permissions (warning) - open

--- a/issues/codescan/alert_14.md
+++ b/issues/codescan/alert_14.md
@@ -1,0 +1,10 @@
+# Code Scanning Alert #14: cpp/overflowing-snprintf
+
+- **State:** open
+- **Severity:** warning
+- **Tool:** CodeQL
+- **Created:** 2026-07-04T22:57:01Z
+- **URL:** https://github.com/grisuno/FreeDom/security/code-scanning/14
+
+## Description
+Potentially overflowing call to snprintf


### PR DESCRIPTION
Automated security export generated on 20260707_005105.

This PR adds a snapshot under `issues/` with:
- All GitHub issues (open + closed) as `issue_<n>.md`
- Open Dependabot alerts under `issues/dependabot/`
- Open Code Scanning alerts under `issues/codescan/`
- Index in `issues/README.md`

Each run replaces this branch (and closes any previous PR using the same head), so only the latest snapshot is open at any time.

Generated by `security_issue_progressive.sh`.