### PR TITLE
Security Export: Issues, Dependabot & CodeScan Alerts

### DIFF
--- a/issues/README.md
+++ b/issues/README.md
@@ -4,16 +4,21 @@
 
 | Metric | Value |
 |--------|-------|
-| ⭐ Stars | 17 |
-| 📥 Clones (last 14 days) | 1400 |
-| 🟢 Open Issues | 1 |
+| ⭐ Stars | 18 |
+| 📥 Clones (last 14 days) | 266 |
+| 🟢 Open Issues | 2 |
 | 📋 Total Issues | 0 |
 | 🛡 Dependabot Open Alerts | 0 |
-| 🔍 CodeScan Open Alerts | 1 |
+| 🔍 CodeScan Open Alerts | 6 |
 
 ## Issues
 
 ## Code Scanning Alerts
+- [CodeScan #23](./codescan/alert_23.md) - py/bad-tag-filter (warning) - open
+- [CodeScan #22](./codescan/alert_22.md) - py/bad-tag-filter (warning) - open
+- [CodeScan #21](./codescan/alert_21.md) - cpp/overflowing-snprintf (warning) - open
+- [CodeScan #20](./codescan/alert_20.md) - cpp/overflowing-snprintf (warning) - open
+- [CodeScan #19](./codescan/alert_19.md) - actions/missing-workflow-permissions (warning) - open
 - [CodeScan #2](./codescan/alert_2.md) - cpp/integer-multiplication-cast-to-long (warning) - open
 
 Total issues downloaded: 0

--- a/issues/codescan/alert_19.md
+++ b/issues/codescan/alert_19.md
@@ -1,0 +1,10 @@
+# Code Scanning Alert #19: actions/missing-workflow-permissions
+
+- **State:** open
+- **Severity:** warning
+- **Tool:** CodeQL
+- **Created:** 2026-07-17T06:03:05Z
+- **URL:** https://github.com/grisuno/FreeDom/security/code-scanning/19
+
+## Description
+Workflow does not contain permissions

--- a/issues/codescan/alert_20.md
+++ b/issues/codescan/alert_20.md
@@ -1,0 +1,10 @@
+# Code Scanning Alert #20: cpp/overflowing-snprintf
+
+- **State:** open
+- **Severity:** warning
+- **Tool:** CodeQL
+- **Created:** 2026-07-30T01:00:09Z
+- **URL:** https://github.com/grisuno/FreeDom/security/code-scanning/20
+
+## Description
+Potentially overflowing call to snprintf

--- a/issues/codescan/alert_21.md
+++ b/issues/codescan/alert_21.md
@@ -1,0 +1,10 @@
+# Code Scanning Alert #21: cpp/overflowing-snprintf
+
+- **State:** open
+- **Severity:** warning
+- **Tool:** CodeQL
+- **Created:** 2026-08-15T01:28:54Z
+- **URL:** https://github.com/grisuno/FreeDom/security/code-scanning/21
+
+## Description
+Potentially overflowing call to snprintf

--- a/issues/codescan/alert_22.md
+++ b/issues/codescan/alert_22.md
@@ -1,0 +1,10 @@
+# Code Scanning Alert #22: py/bad-tag-filter
+
+- **State:** open
+- **Severity:** warning
+- **Tool:** CodeQL
+- **Created:** 2026-08-18T01:24:09Z
+- **URL:** https://github.com/grisuno/FreeDom/security/code-scanning/22
+
+## Description
+Bad HTML filtering regexp

--- a/issues/codescan/alert_23.md
+++ b/issues/codescan/alert_23.md
@@ -1,0 +1,10 @@
+# Code Scanning Alert #23: py/bad-tag-filter
+
+- **State:** open
+- **Severity:** warning
+- **Tool:** CodeQL
+- **Created:** 2026-08-23T07:01:40Z
+- **URL:** https://github.com/grisuno/FreeDom/security/code-scanning/23
+
+## Description
+Bad HTML filtering regexp


### PR DESCRIPTION
Automated security export generated on 20260823_031528.

This PR adds a snapshot under `issues/` with:
- All GitHub issues (open + closed) as `issue_<n>.md`
- Open Dependabot alerts under `issues/dependabot/`
- Open Code Scanning alerts under `issues/codescan/`
- Index in `issues/README.md`

Each run replaces this branch (and closes any previous PR using the same head), so only the latest snapshot is open at any time.

Generated by `security_issue_progressive.sh`.